### PR TITLE
Updated logrus and zap logger names

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -53,7 +53,7 @@ func Example() {
 	switch log.Current.(type) {
 	case *log.StdLogger:
 		fmt.Println("The default logger")
-	case *logrus.Logrus:
+	case *logrus.Logger:
 		fmt.Printf("Logrus is used for logging")
 	default:
 		fmt.Printf("Something else that implements the interface")

--- a/impl/logrus/logrus.go
+++ b/impl/logrus/logrus.go
@@ -7,140 +7,140 @@ import (
 
 // Logrus is a logger that wraps the logrus logger and has it conform to the
 // log.Logger interface
-type Logrus struct {
+type Logger struct {
 	logger *logrus.Logger
 }
 
 // New takes an existing logrus logger and uses that for logging
-func New(lgr *logrus.Logger) *Logrus {
-	return &Logrus{
+func New(lgr *logrus.Logger) *Logger {
+	return &Logger{
 		logger: lgr,
 	}
 }
 
 // NewStandard returns a logger with a logrus standard logger which it
 // instantiates
-func NewStandard() *Logrus {
-	return &Logrus{
+func NewStandard() *Logger {
+	return &Logger{
 		logger: logrus.StandardLogger(),
 	}
 }
 
 // Trace logs a message at the Trace level
-func (l Logrus) Trace(msg ...interface{}) {
+func (l Logger) Trace(msg ...interface{}) {
 	l.logger.Trace(msg...)
 }
 
 // Tracef formats a message according to a format specifier and logs the
 // message at the Trace level
-func (l Logrus) Tracef(template string, args ...interface{}) {
+func (l Logger) Tracef(template string, args ...interface{}) {
 	l.logger.Tracef(template, args...)
 }
 
 // Tracew logs a message at the Trace level along with some additional
 // context (key-value pairs)
-func (l Logrus) Tracew(msg string, fields log.Fields) {
+func (l Logger) Tracew(msg string, fields log.Fields) {
 	l.logger.WithFields(logrus.Fields(fields)).Trace(msg)
 }
 
 // Debug logs a message at the Debug level
-func (l Logrus) Debug(msg ...interface{}) {
+func (l Logger) Debug(msg ...interface{}) {
 	l.logger.Debug(msg...)
 }
 
 // Debugf formats a message according to a format specifier and logs the
 // message at the Debug level
-func (l Logrus) Debugf(template string, args ...interface{}) {
+func (l Logger) Debugf(template string, args ...interface{}) {
 	l.logger.Debugf(template, args...)
 }
 
 // Debugw logs a message at the Debug level along with some additional
 // context (key-value pairs)
-func (l Logrus) Debugw(msg string, fields log.Fields) {
+func (l Logger) Debugw(msg string, fields log.Fields) {
 	l.logger.WithFields(logrus.Fields(fields)).Debug(msg)
 }
 
 // Info logs a message at the Info level
-func (l Logrus) Info(msg ...interface{}) {
+func (l Logger) Info(msg ...interface{}) {
 	l.logger.Info(msg...)
 }
 
 // Infof formats a message according to a format specifier and logs the
 // message at the Info level
-func (l Logrus) Infof(template string, args ...interface{}) {
+func (l Logger) Infof(template string, args ...interface{}) {
 	l.logger.Infof(template, args...)
 }
 
 // Infow logs a message at the Info level along with some additional
 // context (key-value pairs)
-func (l Logrus) Infow(msg string, fields log.Fields) {
+func (l Logger) Infow(msg string, fields log.Fields) {
 	l.logger.WithFields(logrus.Fields(fields)).Info(msg)
 }
 
 // Warn logs a message at the Warn level
-func (l Logrus) Warn(msg ...interface{}) {
+func (l Logger) Warn(msg ...interface{}) {
 	l.logger.Warn(msg...)
 }
 
 // Warnf formats a message according to a format specifier and logs the
 // message at the Warning level
-func (l Logrus) Warnf(template string, args ...interface{}) {
+func (l Logger) Warnf(template string, args ...interface{}) {
 	l.logger.Warnf(template, args...)
 }
 
 // Warnw logs a message at the Warning level along with some additional
 // context (key-value pairs)
-func (l Logrus) Warnw(msg string, fields log.Fields) {
+func (l Logger) Warnw(msg string, fields log.Fields) {
 	l.logger.WithFields(logrus.Fields(fields)).Warn(msg)
 }
 
 // Error logs a message at the Error level
-func (l Logrus) Error(msg ...interface{}) {
+func (l Logger) Error(msg ...interface{}) {
 	l.logger.Error(msg...)
 }
 
 // Errorf formats a message according to a format specifier and logs the
 // message at the Error level
-func (l Logrus) Errorf(template string, args ...interface{}) {
+func (l Logger) Errorf(template string, args ...interface{}) {
 	l.logger.Errorf(template, args...)
 }
 
 // Errorw logs a message at the Error level along with some additional
 // context (key-value pairs)
-func (l Logrus) Errorw(msg string, fields log.Fields) {
+func (l Logger) Errorw(msg string, fields log.Fields) {
 	l.logger.WithFields(logrus.Fields(fields)).Error(msg)
 }
 
 // Panic logs a message at the Panic level and panics
-func (l Logrus) Panic(msg ...interface{}) {
+func (l Logger) Panic(msg ...interface{}) {
 	l.logger.Panic(msg...)
 }
 
 // Panicf formats a message according to a format specifier and logs the
 // message at the Panic level and then panics
-func (l Logrus) Panicf(template string, args ...interface{}) {
+func (l Logger) Panicf(template string, args ...interface{}) {
 	l.logger.Panicf(template, args...)
 }
 
 // Panicw logs a message at the Panic level along with some additional
 // context (key-value pairs) and then panics
-func (l Logrus) Panicw(msg string, fields log.Fields) {
+func (l Logger) Panicw(msg string, fields log.Fields) {
 	l.logger.WithFields(logrus.Fields(fields)).Panic(msg)
 }
 
 // Fatal logs a message at the Fatal level and exists the application
-func (l Logrus) Fatal(msg ...interface{}) {
+func (l Logger) Fatal(msg ...interface{}) {
 	l.logger.Fatal(msg...)
 }
 
 // Fatalf formats a message according to a format specifier and logs the
 // message at the Fatal level and exits the application
-func (l Logrus) Fatalf(template string, args ...interface{}) {
+func (l Logger) Fatalf(template string, args ...interface{}) {
 	l.logger.Fatalf(template, args...)
 }
 
 // Fatalw logs a message at the Fatal level along with some additional
 // context (key-value pairs) and exits the application
-func (l Logrus) Fatalw(msg string, fields log.Fields) {
+func (l Logger) Fatalw(msg string, fields log.Fields) {
 	l.logger.WithFields(logrus.Fields(fields)).Fatal(msg)
 }

--- a/impl/logrus/logrus_test.go
+++ b/impl/logrus/logrus_test.go
@@ -13,7 +13,7 @@ import (
 func TestLogrus(t *testing.T) {
 
 	// Test the logger meets the interface
-	var _ log.Logger = new(Logrus)
+	var _ log.Logger = new(Logger)
 
 	var logger = logrus.New()
 	logger.SetLevel(logrus.TraceLevel)

--- a/impl/zap/zap.go
+++ b/impl/zap/zap.go
@@ -9,14 +9,14 @@ import (
 
 // NewSugar creates an instance of Zap that wraps a zap sugared logger. It takes
 // a preconfigured zap sugar logger as an argument
-func NewSugar(lgr *zap.SugaredLogger) *Zap {
-	return &Zap{
+func NewSugar(lgr *zap.SugaredLogger) *Logger {
+	return &Logger{
 		logger:       lgr,
 		TraceEnabled: false,
 	}
 }
 
-type Zap struct {
+type Logger struct {
 	logger *zap.SugaredLogger
 
 	// TraceEnabled turns on the trace level. This also requires the zap logging
@@ -26,7 +26,7 @@ type Zap struct {
 }
 
 // Trace logs a message at the Trace level
-func (l Zap) Trace(msg ...interface{}) {
+func (l Logger) Trace(msg ...interface{}) {
 	if l.TraceEnabled {
 		l.logger.Debug(msg...)
 	}
@@ -34,7 +34,7 @@ func (l Zap) Trace(msg ...interface{}) {
 
 // Tracef formats a message according to a format specifier and logs the
 // message at the Trace level
-func (l Zap) Tracef(template string, args ...interface{}) {
+func (l Logger) Tracef(template string, args ...interface{}) {
 	if l.TraceEnabled {
 		l.logger.Debugf(template, args...)
 	}
@@ -42,111 +42,111 @@ func (l Zap) Tracef(template string, args ...interface{}) {
 
 // Tracew logs a message at the Trace level along with some additional
 // context (key-value pairs)
-func (l Zap) Tracew(msg string, fields log.Fields) {
+func (l Logger) Tracew(msg string, fields log.Fields) {
 	if l.TraceEnabled {
 		l.logger.Debugw(msg, fieldToAny(fields)...)
 	}
 }
 
 // Debug logs a message at the Debug level
-func (l Zap) Debug(msg ...interface{}) {
+func (l Logger) Debug(msg ...interface{}) {
 	l.logger.Debug(msg...)
 }
 
 // Debugf formats a message according to a format specifier and logs the
 // message at the Debug level
-func (l Zap) Debugf(template string, args ...interface{}) {
+func (l Logger) Debugf(template string, args ...interface{}) {
 	l.logger.Debugf(template, args...)
 }
 
 // Debugw logs a message at the Debug level along with some additional
 // context (key-value pairs)
-func (l Zap) Debugw(msg string, fields log.Fields) {
+func (l Logger) Debugw(msg string, fields log.Fields) {
 	l.logger.Debugw(msg, fieldToAny(fields)...)
 }
 
 // Info logs a message at the Info level
-func (l Zap) Info(msg ...interface{}) {
+func (l Logger) Info(msg ...interface{}) {
 	l.logger.Info(msg...)
 }
 
 // Infof formats a message according to a format specifier and logs the
 // message at the Info level
-func (l Zap) Infof(template string, args ...interface{}) {
+func (l Logger) Infof(template string, args ...interface{}) {
 	l.logger.Infof(template, args...)
 }
 
 // Infow logs a message at the Info level along with some additional
 // context (key-value pairs)
-func (l Zap) Infow(msg string, fields log.Fields) {
+func (l Logger) Infow(msg string, fields log.Fields) {
 	l.logger.Infow(msg, fieldToAny(fields)...)
 }
 
 // Warn logs a message at the Warn level
-func (l Zap) Warn(msg ...interface{}) {
+func (l Logger) Warn(msg ...interface{}) {
 	l.logger.Warn(msg...)
 }
 
 // Warnf formats a message according to a format specifier and logs the
 // message at the Warning level
-func (l Zap) Warnf(template string, args ...interface{}) {
+func (l Logger) Warnf(template string, args ...interface{}) {
 	l.logger.Warnf(template, args...)
 }
 
 // Warnw logs a message at the Warning level along with some additional
 // context (key-value pairs)
-func (l Zap) Warnw(msg string, fields log.Fields) {
+func (l Logger) Warnw(msg string, fields log.Fields) {
 	l.logger.Warnw(msg, fieldToAny(fields)...)
 }
 
 // Error logs a message at the Error level
-func (l Zap) Error(msg ...interface{}) {
+func (l Logger) Error(msg ...interface{}) {
 	l.logger.Error(msg...)
 }
 
 // Errorf formats a message according to a format specifier and logs the
 // message at the Error level
-func (l Zap) Errorf(template string, args ...interface{}) {
+func (l Logger) Errorf(template string, args ...interface{}) {
 	l.logger.Errorf(template, args...)
 }
 
 // Errorw logs a message at the Error level along with some additional
 // context (key-value pairs)
-func (l Zap) Errorw(msg string, fields log.Fields) {
+func (l Logger) Errorw(msg string, fields log.Fields) {
 	l.logger.Errorw(msg, fieldToAny(fields)...)
 }
 
 // Panic logs a message at the Panic level and panics
-func (l Zap) Panic(msg ...interface{}) {
+func (l Logger) Panic(msg ...interface{}) {
 	l.logger.Panic(msg...)
 }
 
 // Panicf formats a message according to a format specifier and logs the
 // message at the Panic level and then panics
-func (l Zap) Panicf(template string, args ...interface{}) {
+func (l Logger) Panicf(template string, args ...interface{}) {
 	l.logger.Panicf(template, args...)
 }
 
 // Panicw logs a message at the Panic level along with some additional
 // context (key-value pairs) and then panics
-func (l Zap) Panicw(msg string, fields log.Fields) {
+func (l Logger) Panicw(msg string, fields log.Fields) {
 	l.logger.Panicw(msg, fieldToAny(fields)...)
 }
 
 // Fatal logs a message at the Fatal level and exists the application
-func (l Zap) Fatal(msg ...interface{}) {
+func (l Logger) Fatal(msg ...interface{}) {
 	l.logger.Fatal(msg...)
 }
 
 // Fatalf formats a message according to a format specifier and logs the
 // message at the Fatal level and exits the application
-func (l Zap) Fatalf(template string, args ...interface{}) {
+func (l Logger) Fatalf(template string, args ...interface{}) {
 	l.logger.Fatalf(template, args...)
 }
 
 // Fatalw logs a message at the Fatal level along with some additional
 // context (key-value pairs) and exits the application
-func (l Zap) Fatalw(msg string, fields log.Fields) {
+func (l Logger) Fatalw(msg string, fields log.Fields) {
 	l.logger.Fatalw(msg, fieldToAny(fields)...)
 }
 

--- a/impl/zap/zap_test.go
+++ b/impl/zap/zap_test.go
@@ -14,7 +14,7 @@ import (
 func TestLogrus(t *testing.T) {
 
 	// Test the logger meets the interface
-	var _ log.Logger = new(Zap)
+	var _ log.Logger = new(Logger)
 
 	ts := newTestLogSpy(t)
 	defer ts.AssertPassed()


### PR DESCRIPTION
Other loggers are named Logger with the exception of the standard
or default logger. That way you deal with names like cli.Logger.
zap.Zap is a confusing name while zap.Logger is easier to
understand.